### PR TITLE
Update offerSdp field

### DIFF
--- a/public/api.js
+++ b/public/api.js
@@ -300,7 +300,7 @@ function onGenerateStream_WebRTC() {
   let payload = {
     "command": "sdm.devices.commands.CameraLiveStream.GenerateWebRtcStream",
     "params": {
-      "offer_sdp": offerSDP
+      "offerSdp": offerSDP
     }
   };
 


### PR DESCRIPTION
While `offer_sdp` does work, the Google-approved field to use is `offerSdp`, which aligns it with current documentation.